### PR TITLE
Set up mail delivery methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@
 # Running Club
 
 ### Introduction
-This application is a project aimed at providing a website and membership management system for a UK Athletics affiliated running or athletics club.
+This application is a project aimed at providing a website and membership management system for
+UK Athletics affiliated running or athletics club.
 
 ### Local development
-You will need ruby (currently v2.4.1) and postgresql already installed. 
+You will need ruby (currently v2.4.1) and postgresql already installed.
+In addition, this app uses the Mailcatcher gem in the development environment to provide a simple
+SMTP server to keep all your emails local. If you wish to use it, this in turn requires SQLite3
+and it's development libraries to be installed on your system (consult your distribution's
+package manager).
 
 ```bash
 # Clone this repository:
@@ -15,6 +20,10 @@ cd running_club
 
 # Download all of the required gems and setup the databases
 bin/setup
+
+# Install and run Mailcatcher
+gem install mailcatcher
+mailcatcher
 
 # Start a server, watch for bundle changes and automatically run the test suite on any changes.
 bin/guard

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,12 +63,6 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "running_club_#{Rails.env}"
 
-  config.action_mailer.perform_caching = false
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
@@ -91,4 +85,22 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Email settings
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { host: ENV['host'] }
+  config.action_mailer.smtp_settings = {
+    address:              ENV['smtp_server'],
+    port:                 ENV['smtp_port'],
+    user_name:            ENV['smtp_username'],
+    password:             ENV['smtp_password'],
+    authentication:       'plain',
+    enable_starttls_auto: true
+  }
 end

--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -10,3 +10,11 @@
 #   stripe_api_key: sk_live_EeHnL644i6zo4Iyq4v1KdV9H
 #   stripe_publishable_key: pk_live_9lcthxpSIHbGwmdO941O1XVU
 site_name: 'My Club Name'
+host: 'localhost:3000'
+
+production:
+  host: 'my_real_domain.com'
+  smtp_username: 'username'
+  smtp_password: 'password'
+  smtp_server: 'smtp.example.com'
+  smtp_port: '587'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  config.secret_key = Rails.application.credentials.secret_key_base || ENV['DEVISE_SECURE_KEY']
+  config.secret_key = Rails.application.credentials.secret_key_base
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "no-reply@#{ENV['host']}"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
In development, we are using Mailcatcher to direct emails locally.
Update to README to explain this change and how to set it up. In
production, we are using Sendgrid to deliver them.